### PR TITLE
Bump the gradle group across 1 directory with 2 updates

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,7 +27,7 @@ android {
         implementation "androidx.preference:preference:1.1.1"
         implementation "androidx.viewpager:viewpager:1.0.0"
         implementation "com.google.android.material:material:1.4.0"
-        implementation "com.google.guava:guava:24.1-jre"
+        implementation "com.google.guava:guava:32.0.0-jre"
         implementation "io.noties.markwon:core:$markwonVersion"
         implementation "io.noties.markwon:ext-strikethrough:$markwonVersion"
         implementation "io.noties.markwon:linkify:$markwonVersion"

--- a/termux-shared/build.gradle
+++ b/termux-shared/build.gradle
@@ -9,7 +9,7 @@ android {
         implementation "androidx.annotation:annotation:1.3.0"
         implementation "androidx.core:core:1.6.0"
         implementation "com.google.android.material:material:1.4.0"
-        implementation "com.google.guava:guava:24.1-jre"
+        implementation "com.google.guava:guava:32.0.0-jre"
         implementation "io.noties.markwon:core:$markwonVersion"
         implementation "io.noties.markwon:ext-strikethrough:$markwonVersion"
         implementation "io.noties.markwon:linkify:$markwonVersion"
@@ -23,7 +23,7 @@ android {
         // Do not increment version higher than 2.5 or there
         // will be runtime exceptions on android < 8
         // due to missing classes like java.nio.file.Path.
-        implementation "commons-io:commons-io:2.5"
+        implementation "commons-io:commons-io:2.7"
 
         implementation project(":terminal-view")
 


### PR DESCRIPTION
Bumps the gradle group with 2 updates in the / directory: [com.google.guava:guava](https://github.com/google/guava) and commons-io:commons-io.


Updates `com.google.guava:guava` from 24.1-jre to 32.0.0-jre
- [Release notes](https://github.com/google/guava/releases)
- [Commits](https://github.com/google/guava/commits)

Updates `commons-io:commons-io` from 2.5 to 2.7

---
updated-dependencies:
- dependency-name: com.google.guava:guava dependency-type: direct:production dependency-group: gradle
- dependency-name: commons-io:commons-io dependency-type: direct:production dependency-group: gradle ...